### PR TITLE
增量上传文件

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -4,6 +4,7 @@ const os = require('os')
 const fs = require('hexo-fs')
 const chalk = require('chalk')
 const COS = require('cos-nodejs-sdk-v5')
+const crypto = require('crypto');
 
 module.exports = function (args) {
   // Hexo's Logger
@@ -96,19 +97,49 @@ function checkHexoConfig (args) {
  */
 function uploadFileToCOS (cos, config, file) {
   return new Promise((resolve, reject) => {
-    cos.putObject({
-      Bucket: config.Bucket,
-      Region: config.Region,
-      Key: file.name,
-      Body: fs.createReadStream(file.path)
-    }, (err, data) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(data)
-      }
+    // Get file md5
+    getFileMD5(file.path).then((etag) => {
+      cos.headObject({
+        Bucket: config.Bucket,
+        Region: config.Region,
+        Key: file.name,
+      }, (err, data) => {
+        // if file exists, return
+        if (!err && data.ETag.slice(1, -1) === etag) {
+          console.log('COS file exists:', file.name)
+          resolve(data)
+          return;
+        }
+
+        cos.putObject({
+          Bucket: config.Bucket,
+          Region: config.Region,
+          Key: file.name,
+          Body: fs.createReadStream(file.path)
+        }, (err, data) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(data)
+          }
+        })
+      })
     })
   })
+}
+
+/**
+ * Get file md5
+ * @param {string} path
+ */
+function getFileMD5(path) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('md5');
+    const stream = fs.createReadStream(path);
+    stream.on('error', err => reject(err));
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/sdlzhd/hexo-deployer-cos#readme",
   "dependencies": {
     "chalk": "^2.4.2",
-    "cos-nodejs-sdk-v5": "^2.5.9",
+    "cos-nodejs-sdk-v5": "^2.5.20",
     "hexo-fs": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- 文件已存在不重复上传，加快文件上传速度，减少流量。
- 更新 `cos-nodejs-sdk-v5` 依赖版本